### PR TITLE
Added TmxVec4 and changed loadMask

### DIFF
--- a/com/haxepunk/tmx/TmxEntity.hx
+++ b/com/haxepunk/tmx/TmxEntity.hx
@@ -64,12 +64,13 @@ class TmxEntity extends Entity
 
 	public function loadMask(collideLayer:String = "collide", typeName:String = "solid", skip:Array<Int> = null)
 	{
+		var tileCoords:Array<TmxVec4> = new Array<TmxVec4>();
 		if (!map.layers.exists(collideLayer))
 		{
 #if debug
 				trace("Layer '" + collideLayer + "' doesn't exist");
 #end
-			return;
+			return tileCoords;
 		}
 
 		var gid:Int;
@@ -86,6 +87,7 @@ class TmxEntity extends Entity
 				if (skip == null || Lambda.has(skip, gid) == false)
 				{
 					grid.setTile(col, row, true);
+					tileCoords.push(new TmxVec4(col*map.tileWidth, row*map.tileHeight, map.tileWidth, map.tileHeight));
 				}
 			}
 		}
@@ -93,6 +95,7 @@ class TmxEntity extends Entity
 		this.mask = grid;
 		this.type = typeName;
 		setHitbox(grid.width, grid.height);
+		return tileCoords;
 	}
 
 }

--- a/com/haxepunk/tmx/TmxVec4.hx
+++ b/com/haxepunk/tmx/TmxVec4.hx
@@ -1,0 +1,18 @@
+package com.haxepunk.tmx;
+
+class TmxVec4
+{
+	public var x:Float;
+	public var y:Float;
+	public var width:Float;
+	public var height:Float;
+
+	public function new(x:Float, y:Float, width:Float, height:Float)
+	{
+		this.x = x;
+		this.y = y;
+		this.width = width;
+		this.height = height;
+	}
+
+}


### PR DESCRIPTION
Made loadMask return a vector 4 (TmxVec4) of the coords of the grid
tiles it marked "true", along with the width and height of the tiles.
This allows external physics engine usage as well as manual entity
placement.
