### PR TITLE
Add compressed map in html5 target.

### DIFF
--- a/com/haxepunk/tmx/TmxLayer.hx
+++ b/com/haxepunk/tmx/TmxLayer.hx
@@ -151,12 +151,14 @@ class TmxLayer
 		var result:Array<Array<Int>> = new Array<Array<Int>>();
 		var data:ByteArray = base64ToByteArray(chunk);
 		if(compressed)
-			#if js
-			throw "No support for compressed maps in html5 target!";
-			#end
-			#if !js
+		{
+			#if (js && !format)
+			throw "Need the format library to use compressed map on html5";
+			#else 
 			data.uncompress();
 			#end
+		}
+			
 		data.endian = Endian.LITTLE_ENDIAN;
 		while(data.position < data.length)
 		{


### PR DESCRIPTION
After reviewing the openfl-html5 code I saw that using uncompress was possible, if the format library is used.

Need to add `<haxelib name="format" />` in project.xml,
if not an error message will be displayed.
