### PR TITLE
Fix TxmObjectGroup

### DIFF
--- a/com/haxepunk/tmx/TmxObjectGroup.hx
+++ b/com/haxepunk/tmx/TmxObjectGroup.hx
@@ -28,8 +28,8 @@ class TmxObjectGroup
 		name = source.att.name;
 		x = (source.has.x) ? Std.parseInt(source.att.x) : 0;
 		y = (source.has.y) ? Std.parseInt(source.att.y) : 0;
-		width = Std.parseInt(source.att.width);
-		height = Std.parseInt(source.att.height);
+		width = map.width;
+		height = map.height;
 		visible = (source.has.visible && source.att.visible == "1") ? true : false;
 		opacity = (source.has.opacity) ? Std.parseFloat(source.att.opacity) : 0;
 		


### PR DESCRIPTION
Tiled no longer gives width and height attributes to the ObjectGroup, but they can be taken from the map width and height.