### PR TITLE
Always set debug rect/circle size to at least 1

### DIFF
--- a/com/haxepunk/tmx/TmxObject.hx
+++ b/com/haxepunk/tmx/TmxObject.hx
@@ -61,7 +61,7 @@ class TmxObject
 			shapeMask = new com.haxepunk.masks.Circle(radius, x, y);
 
 #if debug
-			debug_graphic = com.haxepunk.graphics.Image.createCircle(radius, 0xff0000, .6);
+			debug_graphic = com.haxepunk.graphics.Image.createCircle((radius>0)?radius:1, 0xff0000, .6);
 			debug_graphic.x = x;
 			debug_graphic.y = y;
 #end
@@ -69,7 +69,7 @@ class TmxObject
 			shapeMask = new com.haxepunk.masks.Hitbox(width, height, x, y);
 
 #if debug
-			debug_graphic = com.haxepunk.graphics.Image.createRect(width, height, 0xff0000, .6);
+			debug_graphic = com.haxepunk.graphics.Image.createRect((width>0)?width:1, (height>0)?height:1, 0xff0000, .6);
 			debug_graphic.x = x;
 			debug_graphic.y = y;
 #end


### PR DESCRIPTION
HaxePunk doesn't allow zero size rectangle and circle drawing, so this ensures that the size is always at least 1 pixel.

Pull request is to fix the bug in issue #35 where the game crashes in debug mode with zero size objects.
Let me know if using the ? : shorthand isn't clean/allowed. I just went for the shortest solution here.